### PR TITLE
[ENG-950] Fix get-git-repository-name.ts for windows

### DIFF
--- a/generator/konfig-dash/packages/konfig-cli/src/util/get-git-repository-name.ts
+++ b/generator/konfig-dash/packages/konfig-cli/src/util/get-git-repository-name.ts
@@ -1,8 +1,10 @@
 import * as shell from 'shelljs'
 
 export function getGitRepositoryName(): string {
-  const repoName = shell.exec(
-    'basename -s .git `git config --get remote.origin.url`'
-  )
-  return repoName.stdout
+  // get remote url e.g. "https://github.com/konfig-dev/my-sdks.git"
+  const remoteUrl = shell.exec("git config --get remote.origin.url").stdout.trim();
+  // remove leading path to get base name
+  const baseName = remoteUrl.substring(remoteUrl.lastIndexOf('/') + 1);
+  // strip ".git" off the end
+  return baseName.replace(/\.git$/, '');
 }


### PR DESCRIPTION
windows default shell doesnt support backtick substitution - easier to just get the remote url from shell and do any necessary transformations in code