### PR TITLE
[ENG-987] Handle non-existent security requirement in “konfig fix”

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,3 +94,6 @@
 [submodule "customers/openbanking/openbanking-sdks"]
 	path = customers/openbanking/openbanking-sdks
 	url = https://github.com/konfig-dev/openbanking-sdks.git
+[submodule "customers/tubelightcommunications/tubelightcommunications-sdks"]
+	path = customers/tubelightcommunications/tubelightcommunications-sdks
+	url = https://github.com/konfig-dev/tubelightcommunications-sdks.git

--- a/generator/konfig-dash/packages/konfig-cli/src/util/fix-progress.ts
+++ b/generator/konfig-dash/packages/konfig-cli/src/util/fix-progress.ts
@@ -95,6 +95,10 @@ const progressSchema = z.object({
   ignoreObjectsWithNoProperties: z.boolean().optional(),
   ignorePotentialIncorrectType: z.boolean().optional(),
   fixOnlyOneTagName: fixOnlyOneTagNameSchema.or(z.literal(false)).optional(),
+  nonExistentSecurityMapping: z
+    .record(z.string(), z.string().optional())
+    .optional()
+    .default({}),
   validServerUrls: z
     .record(z.string(), z.object({ url: z.string() }).optional())
     .optional()
@@ -220,6 +224,15 @@ export class Progress {
 
   getIgnoreObjectsWithNoProperties() {
     return this.progress.ignoreObjectsWithNoProperties
+  }
+
+  getNonExistentSecurityMapping(name: string) {
+    return this.progress.nonExistentSecurityMapping[name]
+  }
+
+  setNonExistentSecurityMapping(name: string, mapping: string) {
+    this.progress.nonExistentSecurityMapping[name] = mapping
+    this.save()
   }
 
   setFixOnlyOneTagNameToFalse() {

--- a/generator/konfig-dash/packages/konfig-lib/src/util/find-redundant-security-requirement-and-parameter.ts
+++ b/generator/konfig-dash/packages/konfig-lib/src/util/find-redundant-security-requirement-and-parameter.ts
@@ -39,10 +39,11 @@ export async function findRedundantSecurityRequirementAndParameter({
   const requiredSecuritySchemes = securityRequirements.flatMap((requirement) =>
     Object.keys(requirement).map((name) => {
       const scheme = securitySchemes[name]
-      if (scheme === undefined)
+      if (scheme === undefined) {
         throw Error(
           `Found security requirement ${name} referring to non-existent security scheme`
         )
+      }
       return scheme
     })
   )


### PR DESCRIPTION
basically, if an operation is referring to a non-existent security requirement we should just auto map it to an existing security requirement with the lowest edit distance as the non-existent security requirement was most likely a typo

we should make this a lint rule too